### PR TITLE
docs: generated `results`

### DIFF
--- a/RESULTS.md
+++ b/RESULTS.md
@@ -1,0 +1,25 @@
+# Results of the `App Platform` experiment...
+
+#### TLDR; Unfortunately, `pnpm`'s `pnpm-lock.yaml` file is not recognized by App Platform by default. 😥
+
+- limit access _specify repo_
+
+![image](https://user-images.githubusercontent.com/10120600/199139744-c4467304-723b-45e6-971c-cd0b61cd9043.png)
+
+- create `app platform` app:
+
+![image](https://user-images.githubusercontent.com/10120600/199139913-015fed28-0789-483f-90e4-432540b186a8.png)
+
+- auto deploy
+
+![image](https://user-images.githubusercontent.com/10120600/199140057-914cbd2a-f08d-41a3-8edc-ef9ff12e0824.png)
+
+- provides a clear bill 
+
+![image](https://user-images.githubusercontent.com/10120600/199140748-151cd871-ade3-4508-8306-e4040ba83033.png)
+
+- build failed with `pnpm` 😦 
+
+![image](https://user-images.githubusercontent.com/10120600/199141399-49907259-01a3-46e6-86eb-54d9cf9b8ba2.png)
+
+- I'll have to troubleshoot this to see if there is a work-around.


### PR DESCRIPTION
# `App Platform` Results

- results of using `pnpm` instead of `npm` the default package manager.